### PR TITLE
use pointer arithmetic in bloom.Copy

### DIFF
--- a/bloom/copy.go
+++ b/bloom/copy.go
@@ -28,8 +28,8 @@ func Copy(dst, src []byte) int {
 	n := 0
 
 	if len(dst) >= 64 && simd.copy64 != nil {
-		simd.copy64(unsafebytes.Pointer(dst), unsafebytes.Pointer(src), len(dst)/64)
 		n = (len(dst) / 64) * 64
+		simd.copy64(unsafebytes.Pointer(dst), unsafebytes.Pointer(src), n)
 	}
 
 	if n >= 0 && n < len(dst) && n < len(src) {

--- a/bloom/copy_amd64.go
+++ b/bloom/copy_amd64.go
@@ -3,4 +3,4 @@
 package bloom
 
 // Copies the one-bits of src to dst, using SIMD instructions as an optimization.
-func copyAVX2(dst *byte, src *byte, count int)
+func copyAVX2(dst *byte, src *byte, n int)

--- a/bloom/copy_amd64.s
+++ b/bloom/copy_amd64.s
@@ -2,16 +2,18 @@
 
 #include "textflag.h"
 
-// func copyAVX2(dst *byte, src *byte, count int)
+// func copyAVX2(dst *byte, src *byte, n int)
 // Requires: AVX, AVX2
 TEXT ·copyAVX2(SB), NOSPLIT, $0-24
 	MOVQ dst+0(FP), AX
 	MOVQ src+8(FP), CX
-	MOVQ count+16(FP), DX
+	MOVQ n+16(FP), DX
+	MOVQ AX, BX
+	ADDQ DX, BX
 
 loop:
-	// Loop until zero bytes remain.
-	CMPQ DX, $0x00
+	// Loop until we reach the end.
+	CMPQ AX, BX
 	JE   done
 
 	// Load operands in registers, apply the OR operation, assign the result.
@@ -22,8 +24,7 @@ loop:
 	VMOVUPS Y0, (AX)
 	VMOVUPS Y1, 32(AX)
 
-	// Decrement byte count, advance pointers.
-	DECQ DX
+	// Advance pointers.
 	ADDQ $0x40, AX
 	ADDQ $0x40, CX
 	JMP  loop


### PR DESCRIPTION
Follow up to #1, use pointer arithmetic in the implementation of `copyAVX2`.

This doesn't seem to have a measurable impact, but it makes the code a bit simpler:
```
name  old time/op    new time/op    delta
Copy    55.9ns ± 2%    56.0ns ± 2%   ~     (p=0.841 n=5+5)

name  old speed      new speed      delta
Copy  73.3GB/s ± 2%  73.2GB/s ± 2%   ~     (p=0.841 n=5+5)
```