### PR TITLE
Update reference version in build

### DIFF
--- a/build/go.mod
+++ b/build/go.mod
@@ -4,5 +4,5 @@ go 1.16
 
 require (
 	github.com/mmcloughlin/avo v0.2.0
-	github.com/segmentio/asm v0.0.3-0.20210423204306-fdac5aeb83a3
+	github.com/segmentio/asm v0.0.3
 )

--- a/build/go.sum
+++ b/build/go.sum
@@ -4,6 +4,8 @@ github.com/mmcloughlin/avo v0.2.0 h1:6vhoSaKtxb6f4RiH+LK2qL6GSMpFzhEwJYTTSZNy09w
 github.com/mmcloughlin/avo v0.2.0/go.mod h1:5tidO2Z9Z7N6X7UMcGg+1KTj51O8OxYDCMHxCZTVpEA=
 github.com/segmentio/asm v0.0.3-0.20210423204306-fdac5aeb83a3 h1:FKj9moO1rymChwuV0E4vG7+SJWBCwm12Zthd75CIDjc=
 github.com/segmentio/asm v0.0.3-0.20210423204306-fdac5aeb83a3/go.mod h1:4EUJGaKsB8ImLUwOGORVsNd9vTRDeh44JGsY4aKp5I4=
+github.com/segmentio/asm v0.0.3 h1:ciVBxfM3cIEuGR1VDXPCxdz+Qo+wxlrrt7AkycMJcts=
+github.com/segmentio/asm v0.0.3/go.mod h1:4EUJGaKsB8ImLUwOGORVsNd9vTRDeh44JGsY4aKp5I4=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/arch v0.0.0-20210405154355-08b684f594a5/go.mod h1:flIaEI6LNU6xOCD5PaJvn9wGP0agmIOqjrtsKGRguv4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
This updates the reference from `./build/go.mod` to the latest tagged version of `asm`. This is the version of the `cpu` sub-package used by the feature detection functions (`JumpIfFeature` and `JumpUnlessFeature`).