### PR TITLE
Simplify Dedupe() loop

### DIFF
--- a/build/sortedset/dedupe16_asm.go
+++ b/build/sortedset/dedupe16_asm.go
@@ -37,6 +37,7 @@ func main() {
 	// Load the item at the input pointer.
 	item := XMM()
 	MOVUPS(Mem{Base: src}, item)
+	ADDQ(Imm(16), src)
 
 	// Compare item == prev by comparing the two qwords that make up the 16 byte item.
 	result := XMM()
@@ -47,16 +48,12 @@ func main() {
 	mask := GP32()
 	MOVMSKPD(result, mask)
 	CMPL(mask, Imm(3))
-	JE(LabelRef("next")) // skip the write if they're equal
+	JE(LabelRef("loop")) // skip the write if they're equal
 
 	// Write item to dst and advance the write pointer.
 	MOVUPS(item, Mem{Base: dst})
 	ADDQ(Imm(16), dst)
 	MOVUPS(item, prev)
-
-	// Advance the input pointer and loop.
-	Label("next")
-	ADDQ(Imm(16), src)
 	JMP(LabelRef("loop"))
 
 	Label("done")

--- a/build/sortedset/dedupe32_asm.go
+++ b/build/sortedset/dedupe32_asm.go
@@ -37,6 +37,7 @@ func main() {
 	// Load the item at the input pointer.
 	item := YMM()
 	VMOVUPS(Mem{Base: src}, item)
+	ADDQ(Imm(32), src)
 
 	// Compare item == prev by comparing each byte.
 	result := YMM()
@@ -46,16 +47,12 @@ func main() {
 	mask := GP32()
 	VPMOVMSKB(result, mask)
 	CMPL(mask, U32(0xFFFFFFFF))
-	JE(LabelRef("next")) // skip the write if they're equal
+	JE(LabelRef("loop")) // skip the write if they're equal
 
 	// Write item to dst and advance the write pointer.
 	VMOVUPS(item, Mem{Base: dst})
 	ADDQ(Imm(32), dst)
 	VMOVUPS(item, prev)
-
-	// Advance the input pointer and loop.
-	Label("next")
-	ADDQ(Imm(32), src)
 	JMP(LabelRef("loop"))
 
 	Label("done")

--- a/sortedset/dedupe16_amd64.s
+++ b/sortedset/dedupe16_amd64.s
@@ -17,18 +17,16 @@ loop:
 	CMPQ     AX, DX
 	JE       done
 	MOVUPS   (AX), X1
+	ADDQ     $0x10, AX
 	MOVUPS   X1, X2
 	PCMPEQQ  X0, X2
 	MOVMSKPD X2, BX
 	CMPL     BX, $0x03
-	JE       next
+	JE       loop
 	MOVUPS   X1, (CX)
 	ADDQ     $0x10, CX
 	MOVUPS   X1, X0
-
-next:
-	ADDQ $0x10, AX
-	JMP  loop
+	JMP      loop
 
 done:
 	MOVQ b_base+0(FP), AX

--- a/sortedset/dedupe32_amd64.s
+++ b/sortedset/dedupe32_amd64.s
@@ -17,17 +17,15 @@ loop:
 	CMPQ      AX, DX
 	JE        done
 	VMOVUPS   (AX), Y1
+	ADDQ      $0x20, AX
 	VPCMPEQB  Y0, Y1, Y2
 	VPMOVMSKB Y2, BX
 	CMPL      BX, $0xffffffff
-	JE        next
+	JE        loop
 	VMOVUPS   Y1, (CX)
 	ADDQ      $0x20, CX
 	VMOVUPS   Y1, Y0
-
-next:
-	ADDQ $0x20, AX
-	JMP  loop
+	JMP       loop
 
 done:
 	MOVQ b_base+0(FP), AX


### PR DESCRIPTION
This PR simplifies the `Dedupe()` loop from #7. Instead of incrementing the input pointer in a loop epilogue block, we can increment it just after the load.

```
Dedupe/size_16,_with_0%_chance_of_repeat-4    11.4GB/s ± 1%   17.1GB/s ± 2%  +50.48%  (p=0.008 n=5+5)
Dedupe/size_16,_with_10%_chance_of_repeat-4   8.48GB/s ± 0%  14.56GB/s ± 2%  +71.80%  (p=0.008 n=5+5)
Dedupe/size_16,_with_50%_chance_of_repeat-4   5.12GB/s ± 0%   7.94GB/s ± 2%  +55.08%  (p=0.008 n=5+5)
Dedupe/size_16,_with_100%_chance_of_repeat-4  12.7GB/s ± 0%   12.6GB/s ± 2%     ~     (p=1.000 n=5+5)
Dedupe/size_32,_with_0%_chance_of_repeat-4    17.2GB/s ± 2%   20.5GB/s ± 5%  +19.26%  (p=0.008 n=5+5)
Dedupe/size_32,_with_10%_chance_of_repeat-4   14.4GB/s ± 2%   19.7GB/s ± 0%  +36.77%  (p=0.008 n=5+5)
Dedupe/size_32,_with_50%_chance_of_repeat-4   14.4GB/s ± 2%   18.0GB/s ± 1%  +24.34%  (p=0.008 n=5+5)
Dedupe/size_32,_with_100%_chance_of_repeat-4  16.6GB/s ± 0%   16.7GB/s ± 2%     ~     (p=0.190 n=4+5)
```