### PR TITLE
optimize mem copy tail: MOVQ+ADDQ => LEAQ

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,7 @@ targets := \
 	$(patsubst $(srcdir)/%_asm.go,$(dstdir)/%_amd64.s,$(sources)) \
 	$(patsubst $(srcdir)/%_asm.go,$(dstdir)/%_amd64.go,$(sources))
 
-internal := $(wildcard \
-	$(srcdir)/internal/x86/*.go \
-)
+internal := $(wildcard $(srcdir)/internal/*/*.go)
 
 build: $(targets)
 

--- a/build/internal/gen/copy.go
+++ b/build/internal/gen/copy.go
@@ -129,10 +129,8 @@ func (c *Copy) Generate(name, doc string) {
 
 	dstTail := GP64()
 	srcTail := GP64()
-	MOVQ(dst, dstTail)
-	MOVQ(src, srcTail)
-	ADDQ(n, dstTail)
-	ADDQ(n, srcTail)
+	LEAQ(Mem{Base: dst, Index: n, Scale: 1}, dstTail)
+	LEAQ(Mem{Base: src, Index: n, Scale: 1}, srcTail)
 	SUBQ(Imm(32), dstTail)
 	SUBQ(Imm(32), srcTail)
 

--- a/mem/blend_amd64.s
+++ b/mem/blend_amd64.s
@@ -90,14 +90,12 @@ cmp64:
 cmp32:
 	CMPQ    BX, $0x20
 	JB      cmp8
-	MOVQ    AX, SI
-	MOVQ    CX, DI
-	ADDQ    BX, SI
-	ADDQ    BX, DI
+	LEAQ    (AX)(BX*1), SI
+	LEAQ    (CX)(BX*1), BX
 	SUBQ    $0x20, SI
-	SUBQ    $0x20, DI
+	SUBQ    $0x20, BX
 	VMOVDQU (CX), Y0
-	VMOVDQU (DI), Y1
+	VMOVDQU (BX), Y1
 	VPOR    (AX), Y0, Y0
 	VPOR    (SI), Y1, Y1
 	VMOVDQU Y0, (AX)

--- a/mem/copy_amd64.s
+++ b/mem/copy_amd64.s
@@ -84,14 +84,12 @@ cmp64:
 cmp32:
 	CMPQ    BX, $0x20
 	JB      cmp8
-	MOVQ    AX, SI
-	MOVQ    CX, DI
-	ADDQ    BX, SI
-	ADDQ    BX, DI
+	LEAQ    (AX)(BX*1), SI
+	LEAQ    (CX)(BX*1), BX
 	SUBQ    $0x20, SI
-	SUBQ    $0x20, DI
+	SUBQ    $0x20, BX
 	VMOVDQU (CX), Y0
-	VMOVDQU (DI), Y1
+	VMOVDQU (BX), Y1
 	VMOVDQU Y0, (AX)
 	VMOVDQU Y1, (SI)
 	JMP     done

--- a/mem/mask_amd64.s
+++ b/mem/mask_amd64.s
@@ -90,14 +90,12 @@ cmp64:
 cmp32:
 	CMPQ    BX, $0x20
 	JB      cmp8
-	MOVQ    AX, SI
-	MOVQ    CX, DI
-	ADDQ    BX, SI
-	ADDQ    BX, DI
+	LEAQ    (AX)(BX*1), SI
+	LEAQ    (CX)(BX*1), BX
 	SUBQ    $0x20, SI
-	SUBQ    $0x20, DI
+	SUBQ    $0x20, BX
 	VMOVDQU (CX), Y0
-	VMOVDQU (DI), Y1
+	VMOVDQU (BX), Y1
 	VPAND   (AX), Y0, Y0
 	VPAND   (SI), Y1, Y1
 	VMOVDQU Y0, (AX)


### PR DESCRIPTION
No measurable difference in throughput, but the code is cleaner (and I fixed the source dependencies in the Makefile which broke in #14).