### PR TITLE
optimize generic copy

### DIFF
--- a/build/internal/x86/bytes.go
+++ b/build/internal/x86/bytes.go
@@ -161,12 +161,17 @@ func VariableLengthBytes(inputs []Register, n Register, handle func(inputs []Reg
 	JMP(LabelRef("avx2"))
 
 	Label("generic")
-	handle(inputs, Memory{Size: 16})
+	handle(inputs,
+		Memory{Size: 16},
+		Memory{Size: 16, Offset: 16},
+		Memory{Size: 16, Offset: 32},
+		Memory{Size: 16, Offset: 48},
+	)
 	for i := range inputs {
-		ADDQ(Imm(16), inputs[i])
+		ADDQ(Imm(64), inputs[i])
 	}
-	SUBQ(Imm(16), n)
-	CMPQ(n, Imm(16))
+	SUBQ(Imm(64), n)
+	CMPQ(n, Imm(64))
 	JBE(LabelRef("tail"))
 	JMP(LabelRef("generic"))
 

--- a/mem/blend_amd64.s
+++ b/mem/blend_amd64.s
@@ -40,12 +40,24 @@ tail:
 generic:
 	MOVOU (CX), X0
 	MOVOU (AX), X1
+	MOVOU 16(CX), X2
+	MOVOU 16(AX), X3
+	MOVOU 32(CX), X4
+	MOVOU 32(AX), X5
+	MOVOU 48(CX), X6
+	MOVOU 48(AX), X7
 	POR   X1, X0
+	POR   X3, X2
+	POR   X5, X4
+	POR   X7, X6
 	MOVOU X0, (AX)
-	ADDQ  $0x10, CX
-	ADDQ  $0x10, AX
-	SUBQ  $0x10, DX
-	CMPQ  DX, $0x10
+	MOVOU X2, 16(AX)
+	MOVOU X4, 32(AX)
+	MOVOU X6, 48(AX)
+	ADDQ  $0x40, CX
+	ADDQ  $0x40, AX
+	SUBQ  $0x40, DX
+	CMPQ  DX, $0x40
 	JBE   tail
 	JMP   generic
 

--- a/mem/copy_amd64.s
+++ b/mem/copy_amd64.s
@@ -39,11 +39,17 @@ tail:
 
 generic:
 	MOVOU (CX), X0
+	MOVOU 16(CX), X1
+	MOVOU 32(CX), X2
+	MOVOU 48(CX), X3
 	MOVOU X0, (AX)
-	ADDQ  $0x10, CX
-	ADDQ  $0x10, AX
-	SUBQ  $0x10, DX
-	CMPQ  DX, $0x10
+	MOVOU X1, 16(AX)
+	MOVOU X2, 32(AX)
+	MOVOU X3, 48(AX)
+	ADDQ  $0x40, CX
+	ADDQ  $0x40, AX
+	SUBQ  $0x40, DX
+	CMPQ  DX, $0x40
 	JBE   tail
 	JMP   generic
 

--- a/mem/mask_amd64.s
+++ b/mem/mask_amd64.s
@@ -40,12 +40,24 @@ tail:
 generic:
 	MOVOU (CX), X0
 	MOVOU (AX), X1
+	MOVOU 16(CX), X2
+	MOVOU 16(AX), X3
+	MOVOU 32(CX), X4
+	MOVOU 32(AX), X5
+	MOVOU 48(CX), X6
+	MOVOU 48(AX), X7
 	PAND  X1, X0
+	PAND  X3, X2
+	PAND  X5, X4
+	PAND  X7, X6
 	MOVOU X0, (AX)
-	ADDQ  $0x10, CX
-	ADDQ  $0x10, AX
-	SUBQ  $0x10, DX
-	CMPQ  DX, $0x10
+	MOVOU X2, 16(AX)
+	MOVOU X4, 32(AX)
+	MOVOU X6, 48(AX)
+	ADDQ  $0x40, CX
+	ADDQ  $0x40, AX
+	SUBQ  $0x40, DX
+	CMPQ  DX, $0x40
 	JBE   tail
 	JMP   generic
 


### PR DESCRIPTION
This probably won't have any significant impact on our production use cases, but it speaks the qualities of code generation, and may be a nice addition when we open-source and this code gets run on older CPUs:

Here are the results (disabling the AVX code paths):
```
name         old time/op    new time/op    delta
Copy/N=4096     245ns ± 1%      62ns ± 1%   -74.82%  (p=0.016 n=4+5)

name         old speed      new speed      delta
Copy/N=4096  16.7GB/s ± 1%  66.4GB/s ± 1%  +297.17%  (p=0.016 n=4+5)
```