### PR TITLE
Extract a less mask and bit test rather than load/cmp bytes

### DIFF
--- a/build/sortedset/intersect16_asm.go
+++ b/build/sortedset/intersect16_asm.go
@@ -49,8 +49,8 @@ func main() {
 	VPMOVMSKB(lt, lessMask)
 
 	// Branch based on whether a==b, or a<b.
-	CMPL(unequalMask, U32(0))
-	JE(LabelRef("equal"))
+	TESTL(unequalMask, unequalMask)
+	JZ(LabelRef("equal"))
 	unequalByteIndex := GP32()
 	BSFL(unequalMask, unequalByteIndex)
 	BTSL(unequalByteIndex, lessMask)

--- a/build/sortedset/union16_asm.go
+++ b/build/sortedset/union16_asm.go
@@ -49,8 +49,8 @@ func main() {
 	VPMOVMSKB(lt, lessMask)
 
 	// Branch based on whether a==b, or a<b.
-	CMPL(unequalMask, U32(0))
-	JE(LabelRef("equal"))
+	TESTL(unequalMask, unequalMask)
+	JZ(LabelRef("equal"))
 	unequalByteIndex := GP32()
 	BSFL(unequalMask, unequalByteIndex)
 	BTSL(unequalByteIndex, lessMask)

--- a/sortedset/intersect16_amd64.s
+++ b/sortedset/intersect16_amd64.s
@@ -24,8 +24,8 @@ loop:
 	VPAND     X4, X3, X4
 	VPMOVMSKB X3, DI
 	VPMOVMSKB X4, R8
-	CMPL      DI, $0x00000000
-	JE        equal
+	TESTL     DI, DI
+	JZ        equal
 	BSFL      DI, R9
 	BTSL      R9, R8
 	JCS       less

--- a/sortedset/union16_amd64.s
+++ b/sortedset/union16_amd64.s
@@ -24,8 +24,8 @@ loop:
 	VPAND     X4, X3, X4
 	VPMOVMSKB X3, DI
 	VPMOVMSKB X4, R8
-	CMPL      DI, $0x00000000
-	JE        equal
+	TESTL     DI, DI
+	JZ        equal
 	BSFL      DI, R9
 	BTSL      R9, R8
 	JCS       less


### PR DESCRIPTION
I've been searching for a "gadget" we can use to do bytewise comparisons of two vector registers. It's applicable in the sorted set routines (union/less) and will be applicable in the sorting routines too.

For union/intersect, we need to know whether `a==b`, `a<b` and `a>b` so we know which side to copy and which side to advance. In future, we might also like to branch based on whether `a>=b` and `a<=b`. The ideal gadget would therefore set both ZF and CF in one operation like CMP does. We'd also like it to be as succinct and readable as possible, since it'll be inlined in a few of the sorting routines. I'm not quite there yet but eventually I'd like to find a way to lean on `VPTEST` for this task.

Here's what we had previously — we extract an equality mask, and use it to determine the index of the first unequal byte, which we then load and compare:

```asm
result := XMM()
VPCMPEQB(Mem{Base: a}, b, result)

mask := GP32()
VPMOVMSKB(result, mask)

CMPL(mask, U32(0xFFFF))
JE(LabelRef("equal"))
NOTL(mask)
unequalByteIndex := GP32()
BSFL(mask, unequalByteIndex)
aByte := GP8()
bByte := GP8()
MOVB(Mem{Base: a, Index: unequalByteIndex, Scale: 1}, aByte)
MOVB(Mem{Base: b, Index: unequalByteIndex, Scale: 1}, bByte)
CMPB(aByte, bByte)
JB(LabelRef("less")

Label("greater")
Label("less")
Label("equal")
```

Here's what we have now — we extract two masks (`a!=b` and `a<b`) — then find the first set bit in the first mask (which represents an unequal byte) followed by testing that bit in the second mask:

```asm
ne := XMM()
lt := XMM()
VPCMPEQB(a, b, ne)
VPXOR(ne, ones, ne)
VPMINUB(a, b, lt)
VPCMPEQB(a, lt, lt)
VPAND(lt, ne, lt)

unequalMask := GP32()
lessMask := GP32()
VPMOVMSKB(ne, unequalMask)
VPMOVMSKB(lt, lessMask)

TESTL(unequalMask, unequalMask)
JZ(LabelRef("equal"))
unequalByteIndex := GP32()
BSFL(unequalMask, unequalByteIndex)
BTSL(unequalByteIndex, lessMask)
JCS(LabelRef("less"))

Label("greater")
Label("less")
Label("equal")
```

It's not better in the case where the inputs are the same, but it's better in almost all other cases:

```
name                                              old time/op    new time/op    delta
Intersect/size_16,_with_0%_chance_of_overlap-4      47.0µs ± 0%    40.7µs ± 0%  -13.30%  (p=0.008 n=5+5)
Intersect/size_16,_with_10%_chance_of_overlap-4     39.4µs ± 0%    34.4µs ± 0%  -12.52%  (p=0.008 n=5+5)
Intersect/size_16,_with_50%_chance_of_overlap-4     14.1µs ± 0%    13.3µs ± 1%   -5.73%  (p=0.008 n=5+5)
Intersect/size_16,_with_100%_chance_of_overlap-4    4.74µs ± 0%    5.18µs ± 3%   +9.27%  (p=0.008 n=5+5)
Union/size_16,_with_0%_chance_of_overlap-4          44.3µs ± 0%    39.5µs ± 0%  -10.73%  (p=0.016 n=5+4)
Union/size_16,_with_10%_chance_of_overlap-4         36.8µs ± 0%    34.1µs ± 0%   -7.50%  (p=0.008 n=5+5)
Union/size_16,_with_50%_chance_of_overlap-4         13.9µs ± 4%    14.4µs ± 2%     ~     (p=0.095 n=5+5)
Union/size_16,_with_100%_chance_of_overlap-4        4.84µs ± 3%    5.42µs ± 7%  +11.92%  (p=0.008 n=5+5)

name                                              old speed      new speed      delta
Intersect/size_16,_with_0%_chance_of_overlap-4    2.79GB/s ± 0%  3.22GB/s ± 0%  +15.34%  (p=0.008 n=5+5)
Intersect/size_16,_with_10%_chance_of_overlap-4   3.33GB/s ± 0%  3.81GB/s ± 0%  +14.31%  (p=0.008 n=5+5)
Intersect/size_16,_with_50%_chance_of_overlap-4   9.27GB/s ± 0%  9.83GB/s ± 1%   +6.08%  (p=0.008 n=5+5)
Intersect/size_16,_with_100%_chance_of_overlap-4  27.7GB/s ± 0%  25.3GB/s ± 3%   -8.46%  (p=0.008 n=5+5)
Union/size_16,_with_0%_chance_of_overlap-4        2.96GB/s ± 0%  3.32GB/s ± 0%  +12.02%  (p=0.016 n=5+4)
Union/size_16,_with_10%_chance_of_overlap-4       3.56GB/s ± 0%  3.85GB/s ± 0%   +8.11%  (p=0.008 n=5+5)
Union/size_16,_with_50%_chance_of_overlap-4       9.40GB/s ± 4%  9.11GB/s ± 2%     ~     (p=0.095 n=5+5)
Union/size_16,_with_100%_chance_of_overlap-4      27.1GB/s ± 3%  24.2GB/s ± 7%  -10.51%  (p=0.008 n=5+5)
```