### PR TITLE
Add helper to create load masks

### DIFF
--- a/build/internal/asm/asm.go
+++ b/build/internal/asm/asm.go
@@ -62,6 +62,22 @@ func ConstShuffleMask64(name string, indices ...uint64) operand.Mem {
 	return ConstBytes(name, data)
 }
 
+func ConstLoadMask32(name string, indices ...uint32) operand.Mem {
+	data := make([]uint32, len(indices))
+	for i, index := range indices {
+		data[i] = index << 31
+	}
+	return ConstArray32(name, data...)
+}
+
+func ConstLoadMask64(name string, indices ...uint64) operand.Mem {
+	data := make([]uint64, len(indices))
+	for i, index := range indices {
+		data[i] = index << 63
+	}
+	return ConstArray64(name, data...)
+}
+
 func constBytes8(offset int, data []byte) {
 	for i := 0; i < len(data); i += 8 {
 		DATA(offset+i, operand.U64(binary.LittleEndian.Uint64(data[i:i+8])))


### PR DESCRIPTION
For some upcoming work, we need to load values from memory that may not have valid address for the size of register being loaded into. To validate proper handling during testing, PR #34 was added so that we can construct tests that fault when accessing out of bounds memory. Now to enable loading of memory ranges that span into potentially invalid regions, we can use `VPMASKMOVD` or `VPMASKMOVQ` as long as the invalid offset is at a 4- or 8-byte multiple. To simplify using this, I've added some helper functions to generate `DATA` sections with appropriately generated masks to use when loading.

For example, when using the `Buffer`, this code would fault:

```go
TEXT("LoadOffsetUnsafe", NOSPLIT, "func(a string)")

p := Mem{Base: Load(Param("a").Base(), GP64())}
y := YMM()

VMOVDQU(p.Offset(-4), y)
RET()
```

However, this fault can be avoided by using:

```go
loadOffsetMask := ConstLoadMask32("loadOffsetMask",
	0, 1, 1, 1,
	1, 1, 1, 1,
)

TEXT("LoadOffsetSafe", NOSPLIT, "func(a string)")

p := Mem{Base: Load(Param("a").Base(), GP64())}
y := YMM()

VMOVDQU(loadOffsetMask, y)
VPMASKMOVD(p.Offset(-4), y, y)
RET()
```