### PR TITLE
run go fmt on stub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,6 @@ $(dstdir)/%_amd64.s $(dstdir)/%_amd64.go: $(srcdir)/%_asm.go $(internal)
 		-pkg   $(notdir $(realpath $(dir $<))) \
 		-out   ../$(patsubst $(CURDIR)/%,%,$(patsubst $(srcdir)/%_asm.go,$(dstdir)/%_amd64.s,$<)) \
 		-stubs ../$(patsubst $(CURDIR)/%,%,$(patsubst $(srcdir)/%_asm.go,$(dstdir)/%_amd64.go,$<))
+	go fmt $(dstdir)/$(*)_amd64.go
 
 .PHONY: build


### PR DESCRIPTION
This changes the `Makefile` to run `go fmt` on the stub file generated by AVO. Primarily, the qsort package produces a long function argument list, and there is always a diff produced any time the build re-runs. This should help keep everything tidy.