### PR TITLE
Base64 acceleration for ARM64

### DIFF
--- a/base64/base64_amd64.go
+++ b/base64/base64_amd64.go
@@ -8,22 +8,11 @@ import (
 
 	"github.com/segmentio/asm/cpu"
 	"github.com/segmentio/asm/cpu/x86"
-	"github.com/segmentio/asm/internal/unsafebytes"
 )
 
-// An Encoding is a radix 64 encoding/decoding scheme, defined by a
-// 64-character alphabet.
-type Encoding struct {
-	enc    func(dst []byte, src []byte, lut *int8) (int, int)
-	enclut [32]int8
-
-	dec    func(dst []byte, src []byte, lut *int8) (int, int)
-	declut [48]int8
-
-	base *base64.Encoding
-}
-
 const (
+	encLutSize   = 32
+	decLutSize   = 48
 	minEncodeLen = 28
 	minDecodeLen = 45
 )
@@ -46,7 +35,7 @@ func (e *Encoding) enableEncodeAVX2(encoder string) {
 	// [52..61]  [48..57]    -4  [2..11]  0123456789
 	// [62]      [43]       -19       12  +
 	// [63]      [47]       -16       13  /
-	tab := [32]int8{int8(encoder[0]), int8(encoder[letterRange]) - letterRange}
+	tab := [encLutSize]int8{int8(encoder[0]), int8(encoder[letterRange]) - letterRange}
 	for i, ch := range encoder[2*letterRange:] {
 		tab[2+i] = int8(ch) - 2*letterRange - int8(i)
 	}
@@ -71,7 +60,7 @@ func (e *Encoding) enableDecodeAVX2(encoder string) {
 	// [48..57]   [52..61]   +4        3  0123456789
 	// [65..90]   [0..25]   -65      4,5  ABCDEFGHIJKLMNOPQRSTUVWXYZ
 	// [97..122]  [26..51]  -71      6,7  abcdefghijklmnopqrstuvwxyz
-	tab := [48]int8{
+	tab := [decLutSize]int8{
 		0, 63 - c63, 62 - c62, 4, -65, -65, -71, -71,
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 		0x15, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
@@ -86,75 +75,4 @@ func (e *Encoding) enableDecodeAVX2(encoder string) {
 		e.dec = decodeAVX2
 	}
 	e.declut = tab
-}
-
-// WithPadding creates a duplicate Encoding updated with a specified padding
-// character, or NoPadding to disable padding. The padding character must not
-// be contained in the encoding alphabet, must not be '\r' or '\n', and must
-// be no greater than '\xFF'.
-func (enc Encoding) WithPadding(padding rune) *Encoding {
-	enc.base = enc.base.WithPadding(padding)
-	return &enc
-}
-
-// Strict creates a duplicate encoding updated with strict decoding enabled.
-// This requires that trailing padding bits are zero.
-func (enc Encoding) Strict() *Encoding {
-	enc.base = enc.base.Strict()
-	return &enc
-}
-
-// Encode encodes src using the defined encoding alphabet.
-// This will write EncodedLen(len(src)) bytes to dst.
-func (enc *Encoding) Encode(dst, src []byte) {
-	if len(src) >= minEncodeLen && enc.enc != nil {
-		d, s := enc.enc(dst, src, &enc.enclut[0])
-		dst = dst[d:]
-		src = src[s:]
-	}
-	enc.base.Encode(dst, src)
-}
-
-// Encode encodes src using the encoding enc, writing
-// EncodedLen(len(src)) bytes to dst.
-func (enc *Encoding) EncodeToString(src []byte) string {
-	buf := make([]byte, enc.base.EncodedLen(len(src)))
-	enc.Encode(buf, src)
-	return string(buf)
-}
-
-// EncodedLen calculates the base64-encoded byte length for a message
-// of length n.
-func (enc *Encoding) EncodedLen(n int) int {
-	return enc.base.EncodedLen(n)
-}
-
-// Decode decodes src using the defined encoding alphabet.
-// This will write DecodedLen(len(src)) bytes to dst and return the number of
-// bytes written.
-func (enc *Encoding) Decode(dst, src []byte) (n int, err error) {
-	var d, s int
-	if len(src) >= minDecodeLen && enc.dec != nil {
-		d, s = enc.dec(dst, src, &enc.declut[0])
-		dst = dst[d:]
-		src = src[s:]
-	}
-	n, err = enc.base.Decode(dst, src)
-	n += d
-	return
-}
-
-// DecodeString decodes the base64 encoded string s, returns the decoded
-// value as bytes.
-func (enc *Encoding) DecodeString(s string) ([]byte, error) {
-	src := unsafebytes.BytesOf(s)
-	dst := make([]byte, enc.base.DecodedLen(len(s)))
-	n, err := enc.Decode(dst, src)
-	return dst[:n], err
-}
-
-// DecodedLen calculates the decoded byte length for a base64-encoded message
-// of length n.
-func (enc *Encoding) DecodedLen(n int) int {
-	return enc.base.DecodedLen(n)
 }

--- a/base64/base64_arm64.go
+++ b/base64/base64_arm64.go
@@ -1,0 +1,30 @@
+//go:build arm64 && !purego
+// +build arm64,!purego
+
+package base64
+
+import "encoding/base64"
+
+const (
+	encLutSize   = 16
+	decLutSize   = 48
+	minEncodeLen = 16 * 3
+	minDecodeLen = 8 * 4
+)
+
+func newEncoding(encoder string) *Encoding {
+	e := &Encoding{base: base64.NewEncoding(encoder)}
+	e.enableEncodeARM64(encoder)
+	return e
+}
+
+func (e *Encoding) enableEncodeARM64(encoder string) {
+	c62, c63 := int8(encoder[62]), int8(encoder[63])
+	tab := [encLutSize]int8{
+		'a' - 26, '0' - 52, '0' - 52, '0' - 52, '0' - 52, '0' - 52, '0' - 52, '0' - 52,
+		'0' - 52, '0' - 52, '0' - 52, c62 - 62, c63 - 63, 'A', 0, 0,
+	}
+
+	e.enc = encodeARM64
+	e.enclut = tab
+}

--- a/base64/base64_arm64.go
+++ b/base64/base64_arm64.go
@@ -3,11 +3,13 @@
 
 package base64
 
-import "encoding/base64"
+import (
+	"encoding/base64"
+)
 
 const (
 	encLutSize   = 16
-	decLutSize   = 48
+	decLutSize   = 2
 	minEncodeLen = 16 * 3
 	minDecodeLen = 8 * 4
 )
@@ -15,6 +17,7 @@ const (
 func newEncoding(encoder string) *Encoding {
 	e := &Encoding{base: base64.NewEncoding(encoder)}
 	e.enableEncodeARM64(encoder)
+	e.enableDecodeARM64(encoder)
 	return e
 }
 
@@ -27,4 +30,13 @@ func (e *Encoding) enableEncodeARM64(encoder string) {
 
 	e.enc = encodeARM64
 	e.enclut = tab
+}
+
+func (e *Encoding) enableDecodeARM64(encoder string) {
+	if encoder == encodeStd {
+		e.dec = decodeStdARM64
+	} else {
+		e.dec = decodeARM64
+	}
+	e.declut = [decLutSize]int8{int8(encoder[62]), int8(encoder[63])}
 }

--- a/base64/base64_asm.go
+++ b/base64/base64_asm.go
@@ -1,0 +1,94 @@
+//go:build (amd64 || arm64) && !purego
+// +build amd64 arm64
+// +build !purego
+
+package base64
+
+import (
+	"encoding/base64"
+
+	"github.com/segmentio/asm/internal/unsafebytes"
+)
+
+// An Encoding is a radix 64 encoding/decoding scheme, defined by a
+// 64-character alphabet.
+type Encoding struct {
+	enc    func(dst []byte, src []byte, lut *int8) (int, int)
+	enclut [encLutSize]int8
+
+	dec    func(dst []byte, src []byte, lut *int8) (int, int)
+	declut [decLutSize]int8
+
+	base *base64.Encoding
+}
+
+// WithPadding creates a duplicate Encoding updated with a specified padding
+// character, or NoPadding to disable padding. The padding character must not
+// be contained in the encoding alphabet, must not be '\r' or '\n', and must
+// be no greater than '\xFF'.
+func (enc Encoding) WithPadding(padding rune) *Encoding {
+	enc.base = enc.base.WithPadding(padding)
+	return &enc
+}
+
+// Strict creates a duplicate encoding updated with strict decoding enabled.
+// This requires that trailing padding bits are zero.
+func (enc Encoding) Strict() *Encoding {
+	enc.base = enc.base.Strict()
+	return &enc
+}
+
+// Encode encodes src using the defined encoding alphabet.
+// This will write EncodedLen(len(src)) bytes to dst.
+func (enc *Encoding) Encode(dst, src []byte) {
+	if len(src) >= minEncodeLen && enc.enc != nil {
+		d, s := enc.enc(dst, src, &enc.enclut[0])
+		dst = dst[d:]
+		src = src[s:]
+	}
+	enc.base.Encode(dst, src)
+}
+
+// Encode encodes src using the encoding enc, writing
+// EncodedLen(len(src)) bytes to dst.
+func (enc *Encoding) EncodeToString(src []byte) string {
+	buf := make([]byte, enc.base.EncodedLen(len(src)))
+	enc.Encode(buf, src)
+	return string(buf)
+}
+
+// EncodedLen calculates the base64-encoded byte length for a message
+// of length n.
+func (enc *Encoding) EncodedLen(n int) int {
+	return enc.base.EncodedLen(n)
+}
+
+// Decode decodes src using the defined encoding alphabet.
+// This will write DecodedLen(len(src)) bytes to dst and return the number of
+// bytes written.
+func (enc *Encoding) Decode(dst, src []byte) (n int, err error) {
+	var d, s int
+	if len(src) >= minDecodeLen && enc.dec != nil {
+		d, s = enc.dec(dst, src, &enc.declut[0])
+		dst = dst[d:]
+		src = src[s:]
+	}
+	n, err = enc.base.Decode(dst, src)
+	n += d
+	return
+}
+
+// DecodeString decodes the base64 encoded string s, returns the decoded
+// value as bytes.
+func (enc *Encoding) DecodeString(s string) ([]byte, error) {
+	src := unsafebytes.BytesOf(s)
+	dst := make([]byte, enc.base.DecodedLen(len(s)))
+	n, err := enc.Decode(dst, src)
+	return dst[:n], err
+}
+
+// DecodedLen calculates the decoded byte length for a base64-encoded message
+// of length n.
+func (enc *Encoding) DecodedLen(n int) int {
+	return enc.base.DecodedLen(n)
+}

--- a/base64/base64_asm_test.go
+++ b/base64/base64_asm_test.go
@@ -1,5 +1,6 @@
-//go:build amd64 && !purego
-// +build amd64,!purego
+//go:build (amd64 || arm64) && !purego
+// +build amd64 arm64
+// +build !purego
 
 package base64
 
@@ -25,7 +26,7 @@ func fillBuffers(b *buffer.Buffer, size int) map[string][]byte {
 	return bufs
 }
 
-func TestEncodeAVX2(t *testing.T) {
+func TestEncodeASM(t *testing.T) {
 	b, err := buffer.New(512)
 	if err != nil {
 		t.Fatal(err)
@@ -36,7 +37,7 @@ func TestEncodeAVX2(t *testing.T) {
 
 	for _, enc := range encodings {
 		if enc.candidate.enc == nil {
-			t.Log("AVX2 not enabled")
+			t.Log("asm not enabled")
 			continue
 		}
 		for name, buf := range bufs {
@@ -49,8 +50,8 @@ func TestEncodeAVX2(t *testing.T) {
 
 				_, ns := enc.candidate.enc(dst.ProtectTail(), buf, &enc.candidate.enclut[0])
 
-				if len(buf)-ns >= 32 {
-					t.Errorf("encode remain should be less than 32, but is %d", len(buf)-ns)
+				if len(buf)-ns >= minEncodeLen {
+					t.Errorf("encode remain should be less than %d, but is %d", minEncodeLen, len(buf)-ns)
 				}
 			})
 
@@ -61,7 +62,7 @@ func TestEncodeAVX2(t *testing.T) {
 	}
 }
 
-func TestDecodeAVX2(t *testing.T) {
+func TestDecodeASM(t *testing.T) {
 	b, err := buffer.New(512)
 	if err != nil {
 		t.Fatal(err)
@@ -72,7 +73,7 @@ func TestDecodeAVX2(t *testing.T) {
 
 	for _, enc := range encodings {
 		if enc.candidate.dec == nil {
-			t.Log("AVX2 not enabled")
+			t.Log("asm not enabled")
 			continue
 		}
 
@@ -89,8 +90,8 @@ func TestDecodeAVX2(t *testing.T) {
 
 				_, ns := enc.candidate.dec(dst.ProtectTail(), src, &enc.candidate.declut[0])
 
-				if len(buf)-ns >= 45 {
-					t.Errorf("decode remain should be less than 45, but is %d", len(buf)-ns)
+				if len(buf)-ns >= minDecodeLen {
+					t.Errorf("decode remain should be less than %d, but is %d", minDecodeLen, len(buf)-ns)
 				}
 			})
 

--- a/base64/base64_default.go
+++ b/base64/base64_default.go
@@ -1,5 +1,5 @@
-//go:build purego || !amd64
-// +build purego !amd64
+//go:build purego || !(amd64 || arm64)
+// +build purego !amd64,!arm64
 
 package base64
 

--- a/base64/decode_arm64.go
+++ b/base64/decode_arm64.go
@@ -1,0 +1,7 @@
+//go:build !purego
+// +build !purego
+
+package base64
+
+func decodeARM64(dst []byte, src []byte, lut *int8) (int, int)
+func decodeStdARM64(dst []byte, src []byte, lut *int8) (int, int)

--- a/base64/decode_arm64.s
+++ b/base64/decode_arm64.s
@@ -24,7 +24,6 @@
 	VMOVI   $47, V6.B8;                                          \
 	VMOVI   $15, V7.B8;                                          \
 	VMOVI   $16, V8.B8;                                          \
-	VMOVI   $0, V9.B8
 
 #define LOAD_INPUT()                                           \
 	VLD4    (R4), [V10.B8, V11.B8, V12.B8, V13.B8]
@@ -64,10 +63,10 @@
 	VAND    V23.B8, V27.B8, V27.B8;                              \
 	VAND    V24.B8, V28.B8, V28.B8;                              \
 	VAND    V25.B8, V29.B8, V29.B8;                              \
-	VCMEQ   V9.B8, V26.B8, V26.B8;                               \
-	VCMEQ   V9.B8, V27.B8, V27.B8;                               \
-	VCMEQ   V9.B8, V28.B8, V28.B8;                               \
-	VCMEQ   V9.B8, V29.B8, V29.B8;                               \
+	WORD    $0x0e209b5a /* VCMEQ   $0, V26.B8, V26.B8 */;        \
+	WORD    $0x0e209b7b /* VCMEQ   $0, V27.B8, V27.B8 */;        \
+	WORD    $0x0e209b9c /* VCMEQ   $0, V28.B8, V28.B8 */;        \
+	WORD    $0x0e209bbd /* VCMEQ   $0, V29.B8, V29.B8 */;        \
 	VORR    V26.B8, V27.B8, V26.B8;                              \
 	VORR    V28.B8, V29.B8, V28.B8;                              \
 	VORR    V26.B8, V28.B8, V26.B8;                              \

--- a/base64/decode_arm64.s
+++ b/base64/decode_arm64.s
@@ -1,0 +1,208 @@
+#include "textflag.h"
+
+#define LOAD_ARGS()                                            \
+	MOVD    dst_base+0(FP), R0;                                  \
+	MOVD    R0, R3;                                              \
+	MOVD    src_base+24(FP), R1;                                 \
+	MOVD    R1, R4;                                              \
+	MOVD    src_len+32(FP), R2;                                  \
+	BIC     $31, R2, R2;                                         \
+	ADD     R1, R2, R2
+
+#define LOAD_ARG_LUT()                                         \
+	MOVD    lut+48(FP), R5;                                      \
+	VLD2R   (R5), [V0.B16, V1.B16]
+
+#define LOAD_CONST_LUT()                                       \
+	MOVD    $·mask_lut(SB), R6;                                  \
+	MOVD    $·bpos_lut(SB), R7;                                  \
+	MOVD    $·shft_lut(SB), R8;                                  \
+	VLD1    (R6), [V2.B16];                                      \
+	VLD1    (R7), [V3.B16];                                      \
+	VLD1    (R8), [V4.B16];                                      \
+	VMOVI   $43, V5.B8;                                          \
+	VMOVI   $47, V6.B8;                                          \
+	VMOVI   $15, V7.B8;                                          \
+	VMOVI   $16, V8.B8;                                          \
+	VMOVI   $0, V9.B8
+
+#define LOAD_INPUT()                                           \
+	VLD4    (R4), [V10.B8, V11.B8, V12.B8, V13.B8]
+
+#define COMPARE_INPUT(v)                                       \
+	VCMEQ   V10.B8, v.B8, V14.B8;                                \
+	VCMEQ   V11.B8, v.B8, V15.B8;                                \
+	VCMEQ   V12.B8, v.B8, V16.B8;                                \
+	VCMEQ   V13.B8, v.B8, V17.B8
+
+#define UPDATE_INPUT(v)                                        \
+	VBIT    V14.B8, v.B8, V10.B8;                                \
+	VBIT    V15.B8, v.B8, V11.B8;                                \
+	VBIT    V16.B8, v.B8, V12.B8;                                \
+	VBIT    V17.B8, v.B8, V13.B8
+
+#define SPLIT_INPUT()                                          \
+	VUSHR   $4, V10.B8, V18.B8;                                  \
+	VUSHR   $4, V11.B8, V19.B8;                                  \
+	VUSHR   $4, V12.B8, V20.B8;                                  \
+	VUSHR   $4, V13.B8, V21.B8;                                  \
+	VAND    V7.B8, V10.B8, V22.B8;                               \
+	VAND    V7.B8, V11.B8, V23.B8;                               \
+	VAND    V7.B8, V12.B8, V24.B8;                               \
+	VAND    V7.B8, V13.B8, V25.B8
+
+#define VALIDATE_INPUT(label)                                  \
+	VTBL    V22.B8, [V2.B8], V22.B8;                             \
+	VTBL    V23.B8, [V2.B8], V23.B8;                             \
+	VTBL    V24.B8, [V2.B8], V24.B8;                             \
+	VTBL    V25.B8, [V2.B8], V25.B8;                             \
+	VTBL    V18.B8, [V3.B8], V26.B8;                             \
+	VTBL    V19.B8, [V3.B8], V27.B8;                             \
+	VTBL    V20.B8, [V3.B8], V28.B8;                             \
+	VTBL    V21.B8, [V3.B8], V29.B8;                             \
+	VAND    V22.B8, V26.B8, V26.B8;                              \
+	VAND    V23.B8, V27.B8, V27.B8;                              \
+	VAND    V24.B8, V28.B8, V28.B8;                              \
+	VAND    V25.B8, V29.B8, V29.B8;                              \
+	VCMEQ   V9.B8, V26.B8, V26.B8;                               \
+	VCMEQ   V9.B8, V27.B8, V27.B8;                               \
+	VCMEQ   V9.B8, V28.B8, V28.B8;                               \
+	VCMEQ   V9.B8, V29.B8, V29.B8;                               \
+	VORR    V26.B8, V27.B8, V26.B8;                              \
+	VORR    V28.B8, V29.B8, V28.B8;                              \
+	VORR    V26.B8, V28.B8, V26.B8;                              \
+	VMOV    V26.D[0], R5;                                        \
+	VMOV    V26.D[1], R6;                                        \
+	ORR     R6, R5;                                              \
+	CBNZ    R5, label
+
+#define COMBINE_RESULTS()                                      \
+	VTBL    V18.B8, [V4.B8], V18.B8;                             \
+	VTBL    V19.B8, [V4.B8], V19.B8;                             \
+	VTBL    V20.B8, [V4.B8], V20.B8;                             \
+	VTBL    V21.B8, [V4.B8], V21.B8;                             \
+	VBIT    V14.B8, V8.B8, V18.B8;                               \
+	VBIT    V15.B8, V8.B8, V19.B8;                               \
+	VBIT    V16.B8, V8.B8, V20.B8;                               \
+	VBIT    V17.B8, V8.B8, V21.B8;                               \
+	VADD    V18.B8, V10.B8, V10.B8;                              \
+	VADD    V19.B8, V11.B8, V11.B8;                              \
+	VADD    V20.B8, V12.B8, V12.B8;                              \
+	VADD    V21.B8, V13.B8, V13.B8;                              \
+	VUSHR   $4, V11.B8, V14.B8;                                  \
+	VUSHR   $2, V12.B8, V15.B8;                                  \
+	VSHL    $2, V10.B8, V10.B8;                                  \
+	VSHL    $4, V11.B8, V11.B8;                                  \
+	VSHL    $6, V12.B8, V12.B8;                                  \
+	VORR    V10.B8, V14.B8, V16.B8;                              \
+	VORR    V11.B8, V15.B8, V17.B8;                              \
+	VORR    V12.B8, V13.B8, V18.B8
+
+#define ADVANCE_LOOP(label)                                    \
+	VST3.P  [V16.B8, V17.B8, V18.B8], 24(R3);                    \
+	ADD     $32, R4;                                             \
+	CMP     R4, R2;                                              \
+	BGT     label
+
+#define RETURN()                                               \
+	SUB     R0, R3;                                              \
+	SUB     R1, R4;                                              \
+	MOVD    R3, ret+56(FP);                                      \
+	MOVD    R4, ret1+64(FP);                                     \
+	RET
+
+
+// func decodeARM64(dst []byte, src []byte, lut *int8) (int, int)
+TEXT ·decodeARM64(SB),NOSPLIT,$0-72
+	LOAD_ARGS()
+	LOAD_ARG_LUT()
+	LOAD_CONST_LUT()
+
+loop:
+	LOAD_INPUT()
+
+	// Compare and normalize the 63rd and 64th characters
+	COMPARE_INPUT(V0)
+	UPDATE_INPUT(V5)
+	COMPARE_INPUT(V1)
+	UPDATE_INPUT(V6)
+
+	SPLIT_INPUT()        // Create hi/lo nibbles
+	VALIDATE_INPUT(done) // Detect invalid input characters
+	COMBINE_RESULTS()    // Shift hi nibbles and Combine results
+	ADVANCE_LOOP(loop)   // Store results and continue
+
+done:
+	RETURN()
+
+
+// func decodeStdARM64(dst []byte, src []byte, lut *int8) (int, int)
+TEXT ·decodeStdARM64(SB),NOSPLIT,$0-72
+	LOAD_ARGS()
+	LOAD_CONST_LUT()
+
+loop:
+	LOAD_INPUT()
+	COMPARE_INPUT(V6)    // Compare to '+'
+	SPLIT_INPUT()        // Create hi/lo nibbles
+	VALIDATE_INPUT(done) // Detect invalid input characters
+	COMBINE_RESULTS()    // Shift hi nibbles and Combine results
+	ADVANCE_LOOP(loop)   // Store results and continue
+
+done:
+	RETURN()
+
+
+DATA  ·mask_lut+0x00(SB)/1, $0xa8
+DATA  ·mask_lut+0x01(SB)/1, $0xf8
+DATA  ·mask_lut+0x02(SB)/1, $0xf8
+DATA  ·mask_lut+0x03(SB)/1, $0xf8
+DATA  ·mask_lut+0x04(SB)/1, $0xf8
+DATA  ·mask_lut+0x05(SB)/1, $0xf8
+DATA  ·mask_lut+0x06(SB)/1, $0xf8
+DATA  ·mask_lut+0x07(SB)/1, $0xf8
+DATA  ·mask_lut+0x08(SB)/1, $0xf8
+DATA  ·mask_lut+0x09(SB)/1, $0xf8
+DATA  ·mask_lut+0x0a(SB)/1, $0xf0
+DATA  ·mask_lut+0x0b(SB)/1, $0x54
+DATA  ·mask_lut+0x0c(SB)/1, $0x50
+DATA  ·mask_lut+0x0d(SB)/1, $0x50
+DATA  ·mask_lut+0x0e(SB)/1, $0x50
+DATA  ·mask_lut+0x0f(SB)/1, $0x54
+GLOBL ·mask_lut(SB), NOPTR|RODATA, $16
+
+DATA  ·bpos_lut+0x00(SB)/1, $0x01
+DATA  ·bpos_lut+0x01(SB)/1, $0x02
+DATA  ·bpos_lut+0x02(SB)/1, $0x04
+DATA  ·bpos_lut+0x03(SB)/1, $0x08
+DATA  ·bpos_lut+0x04(SB)/1, $0x10
+DATA  ·bpos_lut+0x05(SB)/1, $0x20
+DATA  ·bpos_lut+0x06(SB)/1, $0x40
+DATA  ·bpos_lut+0x07(SB)/1, $0x80
+DATA  ·bpos_lut+0x08(SB)/1, $0x00
+DATA  ·bpos_lut+0x09(SB)/1, $0x00
+DATA  ·bpos_lut+0x0a(SB)/1, $0x00
+DATA  ·bpos_lut+0x0b(SB)/1, $0x00
+DATA  ·bpos_lut+0x0c(SB)/1, $0x00
+DATA  ·bpos_lut+0x0d(SB)/1, $0x00
+DATA  ·bpos_lut+0x0e(SB)/1, $0x00
+DATA  ·bpos_lut+0x0f(SB)/1, $0x00
+GLOBL ·bpos_lut(SB), NOPTR|RODATA, $16
+
+DATA  ·shft_lut+0x00(SB)/1, $0x00
+DATA  ·shft_lut+0x01(SB)/1, $0x00
+DATA  ·shft_lut+0x02(SB)/1, $0x13
+DATA  ·shft_lut+0x03(SB)/1, $0x04
+DATA  ·shft_lut+0x04(SB)/1, $0xbf
+DATA  ·shft_lut+0x05(SB)/1, $0xbf
+DATA  ·shft_lut+0x06(SB)/1, $0xb9
+DATA  ·shft_lut+0x07(SB)/1, $0xb9
+DATA  ·shft_lut+0x08(SB)/1, $0x00
+DATA  ·shft_lut+0x09(SB)/1, $0x00
+DATA  ·shft_lut+0x0a(SB)/1, $0x00
+DATA  ·shft_lut+0x0b(SB)/1, $0x00
+DATA  ·shft_lut+0x0c(SB)/1, $0x00
+DATA  ·shft_lut+0x0d(SB)/1, $0x00
+DATA  ·shft_lut+0x0e(SB)/1, $0x00
+DATA  ·shft_lut+0x0f(SB)/1, $0x00
+GLOBL ·shft_lut(SB), NOPTR|RODATA, $16

--- a/base64/decode_arm64.s
+++ b/base64/decode_arm64.s
@@ -51,7 +51,7 @@
 	VAND    V7.B8, V11.B8, V23.B8;                               \
 	VAND    V7.B8, V12.B8, V24.B8;                               \
 	VAND    V7.B8, V13.B8, V25.B8;                               \
-  /* Detect invalid input characters */                        \
+	/* Detect invalid input characters */                        \
 	VTBL    V22.B8, [V2.B8], V22.B8;                             \
 	VTBL    V23.B8, [V2.B8], V23.B8;                             \
 	VTBL    V24.B8, [V2.B8], V24.B8;                             \

--- a/base64/decode_arm64.s
+++ b/base64/decode_arm64.s
@@ -98,11 +98,11 @@
 	VORR    V11.B8, V15.B8, V17.B8;                              \
 	VORR    V12.B8, V13.B8, V18.B8
 
-#define ADVANCE_LOOP(goto_done)                                \
+#define ADVANCE_LOOP(goto_loop)                                \
 	VST3.P  [V16.B8, V17.B8, V18.B8], 24(R3);                    \
 	ADD     $32, R4;                                             \
 	CMP     R4, R2;                                              \
-	BGT     goto_done
+	BGT     goto_loop
 
 #define RETURN()                                               \
 	SUB     R0, R3;                                              \

--- a/base64/encode_arm64.go
+++ b/base64/encode_arm64.go
@@ -1,0 +1,6 @@
+//go:build !purego
+// +build !purego
+
+package base64
+
+func encodeARM64(dst []byte, src []byte, lut *int8) (int, int)

--- a/base64/encode_arm64.s
+++ b/base64/encode_arm64.s
@@ -1,86 +1,100 @@
 #include "textflag.h"
 
-#define Rdst R6
-#define Rsrc R5
-#define Rlen R1
-#define Rrd  R2
-#define Rwr  R3
-#define Rlut R0
-#define Ridx R0
+#define Rdst  R0
+#define Rsrc  R1
+#define Rlen  R2
+#define Rwr   R3
+#define Rrem  R4
+#define Rtmp  R5
+
+#define Vlut V0
+#define Vfld0 V6
+#define Vfld1 V7
+#define Vfld2 V8
+#define Vfld3 V9
+#define Vsrc0 V10
+#define Vsrc1 V11
+#define Vsrc2 V12
+#define Vr0a V13
+#define Vr1a V14
+#define Vr2a V15
+#define Vr3a V16
+#define Vr0b V17
+#define Vr1b V18
+#define Vr2b V19
+#define Vr3b V20
 
 // func encodeARM64(dst []byte, src []byte, lut *int8) (int, int)
 TEXT ·encodeARM64(SB),NOSPLIT,$0-72
+	// Load dst/src info
 	MOVD    dst_base+0(FP), Rdst
 	MOVD    src_base+24(FP), Rsrc
 	MOVD    src_len+32(FP), Rlen
-	MOVD    lut+48(FP), Rlut
-	VLD1    (Rlut), [V6.B16]
-	VMOVI   $51, V17.B16
-	VMOVI   $25, V16.B16
-	VMOVI   $63, V19.B16
-	VMOVI   $13, V7.B16
+	MOVD    lut+48(FP), Rtmp
+	VLD1    (Rtmp), [Vlut.B16]
 
+	MOVD    Rlen, Rrem
 	MOVD    Rdst, Rwr
-	MOVD    Rsrc, Rrd
+
+	VMOVI   $51, V1.B16
+	VMOVI   $26, V2.B16
+	VMOVI   $63, V3.B16
+	VMOVI   $13, V4.B16
 
 loop:
-	SUB     $48, Rlen, Rlen
-	VLD3.P  48(Rrd), [V25.B16, V26.B16, V27.B16]
-	VUSHR   $4, V26.B16, V4.B16
-	VSHL    $4, V25.B16, V22.B16
-	VUSHR   $2, V25.B16, V28.B16
-	VUSHR   $6, V27.B16, V18.B16
-	VSHL    $2, V26.B16, V21.B16
-	VORR    V4.B16, V22.B16, V22.B16
-	WORD    $0x6e3c3e04 //VCMHS   V28.B16, V16.B16, V4.B16
-	WORD    $0x6e312f85 //VUQSUB  V17.B16, V28.B16, V5.B16
-	VORR    V18.B16, V21.B16, V21.B16
-	VAND    V19.B16, V22.B16, V22.B16
-	VAND    V7.B16, V4.B16, V4.B16
-	VAND    V27.B16, V19.B16, V18.B16
-	VAND    V19.B16, V21.B16, V21.B16
-	WORD    $0x6e363e14 //VCMHS   V22.B16, V16.B16, V20.B16
-	VORR    V5.B16, V4.B16, V4.B16
-	WORD    $0x6e312ed7 //VUQSUB  V17.B16, V22.B16, V23.B16
-	VTBL    V4.B8, [V6.B16], V24.B8
-	WORD    $0x6e353e05 //VCMHS   V21.B16, V16.B16, V5.B16
-	VAND    V7.B16, V20.B16, V20.B16
-	VDUP    V24.D[0], V24
-	VDUP    V4.D[1], V4
-	VAND    V7.B16, V5.B16, V5.B16
-	VORR    V23.B16, V20.B16, V20.B16
-	VTBL    V4.B8, [V6.B16], V4.B8
-	VTBL    V20.B8, [V6.B16], V23.B8
-	VMOV    V4.D[0], V24.D[1]
-	WORD    $0x6e312eb9 //VUQSUB  V17.B16, V21.B16, V25.B16
-	VDUP    V23.D[0], V23
-	WORD    $0x6e323e04 //VCMHS   V18.B16, V16.B16, V4.B16
-	VADD    V28.B16, V24.B16, V0.B16
-	VORR    V25.B16, V5.B16, V5.B16
-	VDUP    V20.D[1], V20
-	VAND    V7.B16, V4.B16, V4.B16
-	VTBL    V20.B8, [V6.B16], V20.B8
-	WORD    $0x6e312e58 //VUQSUB  V17.B16, V18.B16, V24.B16
-	VMOV    V20.D[0], V23.D[1]
-	VTBL    V5.B8, [V6.B16], V20.B8
-	VDUP    V20.D[0], V20
-	VORR    V24.B16, V4.B16, V4.B16
-	VDUP    V5.D[1], V5
-	VTBL    V5.B8, [V6.B16], V5.B8
-	VMOV    V5.D[0], V20.D[1]
-	VTBL    V4.B8, [V6.B16], V5.B8
-	VDUP    V5.D[0], V5
-	VDUP    V4.D[1], V4
-	VTBL    V4.B8, [V6.B16], V4.B8
-	VADD    V22.B16, V23.B16, V1.B16
-	VMOV    V4.D[0], V5.D[1]
-	VADD    V21.B16, V20.B16, V2.B16
-	VADD    V18.B16, V5.B16, V3.B16
-	VST4.P  [V0.B16, V1.B16, V2.B16, V3.B16], 64(Rwr)
-	CMP     $48, Rlen
-	BHS     loop
-	SUB     Rdst, Rwr, R0
-	SUB     Rsrc, Rrd, R1
-	MOVD    R0, ret+56(FP)
-	MOVD    R1, ret1+64(FP)
+	VLD3.P  48(Rsrc), [Vsrc0.B16, Vsrc1.B16, Vsrc2.B16]
+
+	// Split 3 source blocks into 4 lookup inputs
+	VUSHR   $2, Vsrc0.B16, Vfld0.B16
+	VUSHR   $4, Vsrc1.B16, Vfld1.B16
+	VUSHR   $6, Vsrc2.B16, Vfld2.B16
+	VSHL    $4, Vsrc0.B16, Vsrc0.B16
+	VSHL    $2, Vsrc1.B16, Vsrc1.B16
+	VORR    Vsrc0.B16, Vfld1.B16, Vfld1.B16
+	VORR    Vsrc1.B16, Vfld2.B16, Vfld2.B16
+	VAND    V3.B16, Vfld1.B16, Vfld1.B16
+	VAND    V3.B16, Vfld2.B16, Vfld2.B16
+	VAND    V3.B16, Vsrc2.B16, Vfld3.B16
+
+	// if v < 51 { v = 0 } else { v = v - 51 }
+	WORD    $0x6e212ccd // VUQSUB  V1.B16, Vfld0.B16, Vr0a.B16
+	WORD    $0x6e212cee // VUQSUB  V1.B16, Vfld1.B16, Vr1a.B16
+	WORD    $0x6e212d0f // VUQSUB  V1.B16, Vfld2.B16, Vr2a.B16
+	WORD    $0x6e212d30 // VUQSUB  V1.B16, Vfld3.B16, Vr3a.B16
+
+	// Split lookup ranges 0..25 -> 0 and 26..51 -> 13
+	WORD    $0x4e263451 // VCMGT   V2.B16, Vfld0.B16, Vr0b.B16
+	VAND    V4.B16, Vr0b.B16, Vr0b.B16
+	VORR    Vr0b.B16, Vr0a.B16, Vr0a.B16
+	WORD    $0x4e273452 // VCMGT   V2.B16, Vfld1.B16, Vr1b.B16
+	VAND    V4.B16, Vr1b.B16, Vr1b.B16
+	VORR    Vr1b.B16, Vr1a.B16, Vr1a.B16
+	WORD    $0x4e283453 // VCMGT   V2.B16, Vfld2.B16, Vr2b.B16
+	VAND    V4.B16, Vr2b.B16, Vr2b.B16
+	VORR    Vr2b.B16, Vr2a.B16, Vr2a.B16
+	WORD    $0x4e293454 // VCMGT   V2.B16, Vfld3.B16, Vr3b.B16
+	VAND    V4.B16, Vr3b.B16, Vr3b.B16
+	VORR    Vr3b.B16, Vr3a.B16, Vr3a.B16
+
+	// Add result of lookup table to each field
+	VTBL    Vr0a.B16, [Vlut.B16], Vr0a.B16
+	VADD    Vr0a.B16, Vfld0.B16, Vfld0.B16
+	VTBL    Vr1a.B16, [Vlut.B16], Vr1a.B16
+	VADD    Vr1a.B16, Vfld1.B16, Vfld1.B16
+	VTBL    Vr2a.B16, [Vlut.B16], Vr2a.B16
+	VADD    Vr2a.B16, Vfld2.B16, Vfld2.B16
+	VTBL    Vr3a.B16, [Vlut.B16], Vr3a.B16
+	VADD    Vr3a.B16, Vfld3.B16, Vfld3.B16
+
+	VST4.P  [Vfld0.B16, Vfld1.B16, Vfld2.B16, Vfld3.B16], 64(Rwr)
+	SUB     $48, Rrem
+	CMP     $48, Rrem
+	BGE     loop
+
+done:
+	SUB     Rdst, Rwr
+	SUB     Rrem, Rlen
+	MOVD    Rwr, ret+56(FP)
+	MOVD    Rlen, ret1+64(FP)
 	RET
+

--- a/base64/encode_arm64.s
+++ b/base64/encode_arm64.s
@@ -56,22 +56,19 @@ loop:
 	VAND    V3.B16, Vfld2.B16, Vfld2.B16
 	VAND    V3.B16, Vsrc2.B16, Vfld3.B16
 
-	// if v < 51 { v = 0 } else { v = v - 51 }
 	WORD    $0x6e212ccd // VUQSUB  V1.B16, Vfld0.B16, Vr0a.B16
-	WORD    $0x6e212cee // VUQSUB  V1.B16, Vfld1.B16, Vr1a.B16
-	WORD    $0x6e212d0f // VUQSUB  V1.B16, Vfld2.B16, Vr2a.B16
-	WORD    $0x6e212d30 // VUQSUB  V1.B16, Vfld3.B16, Vr3a.B16
-
-	// Split lookup ranges 0..25 -> 0 and 26..51 -> 13
 	WORD    $0x4e263451 // VCMGT   V2.B16, Vfld0.B16, Vr0b.B16
 	VAND    V4.B16, Vr0b.B16, Vr0b.B16
 	VORR    Vr0b.B16, Vr0a.B16, Vr0a.B16
+	WORD    $0x6e212cee // VUQSUB  V1.B16, Vfld1.B16, Vr1a.B16
 	WORD    $0x4e273452 // VCMGT   V2.B16, Vfld1.B16, Vr1b.B16
 	VAND    V4.B16, Vr1b.B16, Vr1b.B16
 	VORR    Vr1b.B16, Vr1a.B16, Vr1a.B16
+	WORD    $0x6e212d0f // VUQSUB  V1.B16, Vfld2.B16, Vr2a.B16
 	WORD    $0x4e283453 // VCMGT   V2.B16, Vfld2.B16, Vr2b.B16
 	VAND    V4.B16, Vr2b.B16, Vr2b.B16
 	VORR    Vr2b.B16, Vr2a.B16, Vr2a.B16
+	WORD    $0x6e212d30 // VUQSUB  V1.B16, Vfld3.B16, Vr3a.B16
 	WORD    $0x4e293454 // VCMGT   V2.B16, Vfld3.B16, Vr3b.B16
 	VAND    V4.B16, Vr3b.B16, Vr3b.B16
 	VORR    Vr3b.B16, Vr3a.B16, Vr3a.B16


### PR DESCRIPTION
This PR introduces ARM64 support for base64.

The general purpose portion of `base64_amd64.go` was moved into `base64_asm.go` while keeping the `AMD64`-specific code isolated. A new `base64_arm64.go` implementation in being introduced to the current implementation.

On a Graviton 2 instance, the benchmarks are looking decent:
```goos: linux
goarch: arm64
pkg: github.com/segmentio/asm/base64
BenchmarkEncode/asm-4            1207927               994.1 ns/op      4120.41 MB/s
BenchmarkEncode/go-4              208002              5759 ns/op         711.18 MB/s
BenchmarkDecode/asm-4             534616              2242 ns/op        2437.53 MB/s
BenchmarkDecode/go-4              233426              5140 ns/op        1063.06 MB/s
```