### PR TITLE
Sort fix

### DIFF
--- a/qsort/sort.go
+++ b/qsort/sort.go
@@ -20,7 +20,7 @@ func Sort(data []byte, size int, swap func(int, int)) {
 	}
 
 	// No specialization available. Use the slower generic sorting routine.
-	if purego || size%8 != 0 || size > 32 {
+	if size%8 != 0 || size > 32 {
 		sort.Sort(newGeneric(data, size, swap))
 		return
 	}
@@ -37,11 +37,11 @@ func Sort(data []byte, size int, swap func(int, int)) {
 	// If no indirect swapping is required, try to use the hybrid partitioning scheme from
 	// https://blog.reverberate.org/2020/05/29/hoares-rebuttal-bubble-sorts-comeback.html
 	switch {
-	case swap == nil && size == 8 && cpu.X86.Has(x86.CMOV):
+	case swap == nil && !purego && size == 8 && cpu.X86.Has(x86.CMOV):
 		hybridQuicksort64(unsafeBytesTo64(data))
-	case swap == nil && size == 16 && cpu.X86.Has(x86.AVX):
+	case swap == nil && !purego && size == 16 && cpu.X86.Has(x86.AVX):
 		hybridQuicksort128(unsafeBytesTo128(data))
-	case swap == nil && size == 32 && cpu.X86.Has(x86.AVX2):
+	case swap == nil && !purego && size == 32 && cpu.X86.Has(x86.AVX2):
 		hybridQuicksort256(unsafeBytesTo256(data))
 	case size == 8:
 		quicksort64(unsafeBytesTo64(data), 0, smallCutoff, insertionsort64, hoarePartition64, swap)

--- a/qsort/sort16.go
+++ b/qsort/sort16.go
@@ -112,5 +112,5 @@ func hybridPartition128(data, scratch []uint128) int {
 }
 
 func less128(a, b uint128) bool {
-	return a.hi < b.hi || (a.hi == b.hi && a.lo <= b.lo)
+	return a.hi < b.hi || (a.hi == b.hi && a.lo < b.lo)
 }

--- a/qsort/sort24.go
+++ b/qsort/sort24.go
@@ -83,5 +83,5 @@ func hoarePartition192(data []uint192, base int, swap func(int, int)) int {
 func less192(a, b uint192) bool {
 	return a.hi < b.hi ||
 		(a.hi == b.hi && a.mid < b.mid) ||
-		(a.hi == b.hi && a.mid == b.mid && a.lo <= b.lo)
+		(a.hi == b.hi && a.mid == b.mid && a.lo < b.lo)
 }

--- a/qsort/sort32.go
+++ b/qsort/sort32.go
@@ -112,5 +112,5 @@ func less256(a, b uint256) bool {
 	return a.a < b.a ||
 		(a.a == b.a && a.b < b.b) ||
 		(a.a == b.a && a.b == b.b && a.c < b.c) ||
-		(a.a == b.a && a.b == b.b && a.c == b.c && a.d <= b.d)
+		(a.a == b.a && a.b == b.b && a.c == b.c && a.d < b.d)
 }

--- a/qsort/sort_test.go
+++ b/qsort/sort_test.go
@@ -81,6 +81,74 @@ func testSort(t *testing.T, size int) {
 	}
 }
 
+func TestPivot8(t *testing.T) {
+	lo := uint64(1)
+	mid := uint64(2)
+	hi := uint64(3)
+
+	for i := 0; i < 1000; i++ {
+		input := []uint64{lo, mid, hi}
+		rand.Shuffle(3, func(i, j int) {
+			input[i], input[j] = input[j], input[i]
+		})
+		medianOfThree64(input, 3, nil)
+		if input[0] != mid {
+			t.Fatal("medianOfThree128 did not put pivot in first position")
+		}
+	}
+}
+
+func TestPivot16(t *testing.T) {
+	lo := uint128{lo: 1}
+	mid := uint128{lo: 2}
+	hi := uint128{lo: 3}
+
+	for i := 0; i < 1000; i++ {
+		input := []uint128{lo, mid, hi}
+		rand.Shuffle(3, func(i, j int) {
+			input[i], input[j] = input[j], input[i]
+		})
+		medianOfThree128(input, 3, nil)
+		if input[0] != mid {
+			t.Fatal("medianOfThree128 did not put pivot in first position")
+		}
+	}
+}
+
+func TestPivot24(t *testing.T) {
+	lo := uint192{lo: 1}
+	mid := uint192{lo: 2}
+	hi := uint192{lo: 3}
+
+	for i := 0; i < 1000; i++ {
+		input := []uint192{lo, mid, hi}
+		rand.Shuffle(3, func(i, j int) {
+			input[i], input[j] = input[j], input[i]
+		})
+		medianOfThree192(input, 3, nil)
+		if input[0] != mid {
+			t.Fatal("medianOfThree192 did not put pivot in first position")
+		}
+	}
+}
+
+func TestPivot32(t *testing.T) {
+	lo := uint256{d: 1}
+	mid := uint256{d: 2}
+	hi := uint256{d: 3}
+
+	for i := 0; i < 1000; i++ {
+		input := []uint256{lo, mid, hi}
+		rand.Shuffle(3, func(i, j int) {
+			input[i], input[j] = input[j], input[i]
+		})
+		medianOfThree256(input, 3, nil)
+		if input[0] != mid {
+			t.Fatal("medianOfThree256 did not put pivot in first position")
+		}
+	}
+}
+
 func randint(lo, hi int) int {
 	if hi == lo {
 		return lo


### PR DESCRIPTION
This fixes a bug where the optimized sorting routines weren't used on ARM64 (where `purego=true`). 

I've also added benchmarks for indirect sorting, and added tests for pivot selection to make sure we aren't triggering worst case quicksort behavior.