### PR TITLE
qsort: add benchmarks from the standard library

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,22 @@
+name: Go
+
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18.x
+
+    - name: Run benchmarks
+      run: |
+        go install golang.org/x/perf/cmd/benchstat@latest
+        make benchcmp count=1

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL = /bin/bash
+
 dstdir := $(CURDIR)
 srcdir := $(CURDIR)/build
 
@@ -16,10 +18,11 @@ build: $(targets)
 
 count ?= 5
 bench ?= .
+pkg ?= ...
 benchcmp:
-	go test -v -run _ -count $(count) -bench $(bench) ./$(pkg) -tags purego | tee /tmp/bench-$(pkg)-purego.txt
-	go test -v -run _ -count $(count) -bench $(bench) ./$(pkg)              | tee /tmp/bench-$(pkg)-asm.txt
-	benchstat /tmp/bench-$(pkg)-{purego,asm}.txt
+	go test -v -run _ -count $(count) -bench $(bench) ./$(pkg) -tags purego > /tmp/bench-$(subst .,dot,$(pkg))-purego.txt
+	go test -v -run _ -count $(count) -bench $(bench) ./$(pkg)              > /tmp/bench-$(subst .,dot,$(pkg))-asm.txt
+	benchstat /tmp/bench-$(subst .,dot,$(pkg))-{purego,asm}.txt
 
 $(dstdir)/%_amd64.s $(dstdir)/%_amd64.go: $(srcdir)/%_asm.go $(internal)
 	cd build && go run $(patsubst $(CURDIR)/build/%,%,$<) \


### PR DESCRIPTION
These will let us be more confident that the qsort makes sense to use,
especially when e.g. the Go standard library introduces a new sorting
algorithm, we can compare the two.

On my Mac, using the pdqsort from Go 1.19, the relevant timings are:

    Sort8/100000-10             4.91ms ± 0%
    Sort8/1000000-10            60.1ms ± 0%
    StdlibSort8/100000-10       8.16ms ± 0%
    StdlibSort8/1000000-10       103ms ± 0%

    Sort8/100000-10            163MB/s ± 0%
    Sort8/1000000-10           133MB/s ± 0%
    StdlibSort8/100000-10     98.0MB/s ± 0%
    StdlibSort8/1000000-10    77.5MB/s ± 0%

Compared to the Go 1.18 sort algorithm:

    Sort8/100000-10             4.90ms ± 0%
    Sort8/1000000-10            59.0ms ± 0%
    StdlibSort8/100000-10       8.53ms ± 0%
    StdlibSort8/1000000-10       105ms ± 0%

    Sort8/100000-10            163MB/s ± 0%
    Sort8/1000000-10           136MB/s ± 0%
    StdlibSort8/100000-10     93.8MB/s ± 0%
    StdlibSort8/1000000-10    76.0MB/s ± 0%

So the Go standard library sort performance is improving but we are
still about 40% faster than the benchmark.