### PR TITLE
LICENSE CHANGE: MIT to MIT-0 (No Attribution)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,16 @@
-MIT License
+MIT No Attribution
 
-Copyright (c) 2021 Segment
+Copyright 2023 Segment
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Switch to a more permissive, no attribution required, license so this code can be included upstream in Golang. No conflicts with any of the dependency licenses were found:

```sh
- github.com/yuin/goldmark @ v1.4.0 / v1.4.13 - MIT - https://github.com/yuin/goldmark/blob/master/LICENSE
- github.com/klauspost/cpuid/v2 @ v2.0.6 - MIT - https://github.com/klauspost/cpuid/blob/master/LICENSE
- github.com/mmcloughlin/avo @ v0.4.0 - MIT - https://github.com/mmcloughlin/avo/blob/master/LICENSE
- rsc.io/pdf - BSD-3 - https://github.com/rsc/pdf/blob/master/LICENSE
- golang.org/x/arch - BSD-3
- golang.org/x/crypto - BSD-3
- golang.org/x/mod - BSD-3
- golang.org/x/net - BSD-3
- golang.org/x/sync - BSD-3
- golang.org/x/sys - BSD-3
- golang.org/x/term - BSD-3
- golang.org/x/text - BSD-3
- golang.org/x/tools  - BSD-3
- golang.org/x/xerrors - BSD-3
```

Closes https://github.com/segmentio/asm/issues/84.

cc @achille-roussel @pelletier @kevinburkesegment @kalamay 